### PR TITLE
fix checking of input-port

### DIFF
--- a/src/popup/whitelist/index.tsx
+++ b/src/popup/whitelist/index.tsx
@@ -50,7 +50,7 @@ export const WhitelistView = (props: WhitelistProps) => {
     }
 
     if(port){
-      if(!Number.isInteger(port)){
+      if(!Number.isInteger(Number(port)) || port <= 0 || port > 65535){
         props.msgApi?.error(t('tip.err.input-port'))
         return
       }


### PR DESCRIPTION
白名单域名添加中，字符串 port 须转为数字才能用 Number.isInteger，不然自定端口就报错“请输入正确的端口号”。顺便加了端口大小判断。