### PR TITLE
fix: missing injected configuration items in compatibility mode

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -11,6 +11,9 @@ const args = _args;
 // ------------
 (() => {
   if (typeof window !== "undefined") {
+    // @ts-ignore
+    args.fun = args.fun ?? coreInject;
+    args.storage = args.storage ?? args;
     const storage: LocalStorage = args.storage;
     if (!window || !storage) return;
 


### PR DESCRIPTION
简要说明：兼容模式下注入脚本时，没有构造成合适的对象

相关讨论： #92 