### PR TITLE
fix(build): generate src/core/output.js early in Vite's configResolved hook

### DIFF
--- a/plugins/core-bundle.ts
+++ b/plugins/core-bundle.ts
@@ -16,7 +16,7 @@ type CoreBundleOptions = {
 
 export const coreBundle = (options: CoreBundleOptions): Plugin => ({
   name: 'core-bundle',
-  async buildStart() {
+  async configResolved() {
     await bundle(options);
   },
   configureServer(server) {


### PR DESCRIPTION
当前构建过程中有两个问题：

1. 如果 `src/core/output.js` 不存在，构建过程中报错：[vite:load-fallback] Could not load src/core/output (imported by src/background/script.ts): ENOENT: no such file or directory
2. 如果 `src/core/output.js` 存在，修改 `src/core` 中的代码后，重复构建时似乎没有使用最新代码

`coreBundle` 插件生成的 `src/core/output.js` 文件被后续的文件引用解析，需要尽可能早的生成。

现在调整了生成该文件的时机，保证了构建不出错。