### PR TITLE
feat: add log API and vite plugin `gen log prefix`

### DIFF
--- a/plugins/core-bundle.ts
+++ b/plugins/core-bundle.ts
@@ -7,6 +7,8 @@ import typescript from '@rollup/plugin-typescript';
 import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 
+import genLogPrefix from './gen-log-prefix';
+
 type CoreBundleOptions = {
   inputFilePath: string
   outputFilePath: string
@@ -32,6 +34,7 @@ async function bundle({ inputFilePath, outputFilePath, functionName, params }: C
   const bundle = await rollup({
     input: inputFilePath,
     plugins: [
+      genLogPrefix("__LOG_PREFIX_FILE_PATH__"),
       resolve(),
       commonjs(),
       typescript({

--- a/plugins/gen-log-prefix.ts
+++ b/plugins/gen-log-prefix.ts
@@ -1,0 +1,44 @@
+import { type Plugin } from "rollup";
+
+/** 当前使用文件路径作为日志的前缀，需要在编译期间获取文件路径，替换提前准备好的占位符。
+ *
+ * 当前只处理 `src` 目录下的文件，将 `src/xxx` 中的 `xxx` 部分作为日志的前缀。
+ *
+ * @param placeholder 占位符名称
+ * @param verbose 输出处理了哪些文件
+ */
+export default function genLogPrefix(
+  placeholder: string,
+  verbose = false,
+): Plugin {
+  const validExtensions = [".ts", ".js", ".tsx", ".jsx", ".mjs", ".cjs"];
+
+  return {
+    name: "gen-log-prefix",
+
+    transform(code, id) {
+      const windowsSrcIndex = id.indexOf("\\src\\");
+      const srcIndex =
+        windowsSrcIndex === -1 ? id.indexOf("/src/") : windowsSrcIndex;
+
+      if (
+        srcIndex === -1 ||
+        id.includes("node_modules") ||
+        !code.includes(placeholder)
+      )
+        return null;
+
+      const hasValidExt = validExtensions.some((ext) => id.endsWith(ext));
+      if (!hasValidExt) return null;
+
+      const extIndex = id.lastIndexOf(".");
+      const relativePath = id
+        // +5 是跳过 /src/ 字符串
+        .substring(srcIndex + 5, extIndex)
+        .replaceAll("\\", "/");
+      verbose && console.log("gen log prefix:", relativePath);
+      const transformed = code.replaceAll(placeholder, `"${relativePath}"`);
+      return transformed;
+    },
+  };
+}

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -5,6 +5,8 @@ import { tryUrl } from "@/utils/base";
 import { reRequestHeader } from "./request";
 import { logManager } from '@/utils/log';
 
+getLocalStorage().then(({ storage }) => logManager.setLevel(storage.config.prefs.logLevel));
+
 const logger = logManager.createLogger(__LOG_PREFIX_FILE_PATH__);
 
 let newVersion: string | undefined
@@ -68,6 +70,8 @@ chrome.runtime.onMessage.addListener(((msg, sender, sendResponse) => {
     }
     case 'config.set': {
       updateContext({ config: msg.config })
+      const logLevel = msg?.config?.prefs?.logLevel;
+      logLevel && logManager.setLevel(logLevel);
       return false
     }
     case 'policies.set': {

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -1,11 +1,9 @@
-import { applySubscribeStorage, getLocalStorage, importContext, initLocalStorage, reBrowserSeed, updateContext } from "./storage";
+import { getLocalStorage, importContext, initLocalStorage, updateContext } from "./storage";
 import { removeBadge, setBadgeContent, setBadgeWhitelist } from "./badge";
 import { injectScript, reRegisterScript } from './script';
 import { tryUrl } from "@/utils/base";
 import { reRequestHeader } from "./request";
 import { logManager } from '@/utils/log';
-
-getLocalStorage().then(({ storage }) => logManager.setLevel(storage.config.prefs.logLevel));
 
 const logger = logManager.createLogger(__LOG_PREFIX_FILE_PATH__);
 
@@ -31,7 +29,6 @@ const getNewVersion = async () => {
 chrome.runtime.onInstalled.addListener(({ reason }) => {
   if (reason === "install" || reason === "update") {
     initLocalStorage()
-    reBrowserSeed()
   }
 });
 
@@ -40,7 +37,6 @@ chrome.runtime.onInstalled.addListener(({ reason }) => {
  */
 chrome.runtime.onStartup.addListener(() => {
   initLocalStorage()
-  reBrowserSeed()
 });
 
 /**

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -3,6 +3,9 @@ import { removeBadge, setBadgeContent, setBadgeWhitelist } from "./badge";
 import { injectScript, reRegisterScript } from './script';
 import { tryUrl } from "@/utils/base";
 import { reRequestHeader } from "./request";
+import { logManager } from '@/utils/log';
+
+const logger = logManager.createLogger(__LOG_PREFIX_FILE_PATH__);
 
 let newVersion: string | undefined
 
@@ -15,6 +18,7 @@ const getNewVersion = async () => {
   } else {
     const data = await fetch('https://api.github.com/repos/omegaee/my-fingerprint/releases/latest').then(data => data.json())
     newVersion = data.tag_name
+    logger.info('getNewVersion fetched version:', newVersion)
     return newVersion
   }
 }
@@ -41,9 +45,11 @@ chrome.runtime.onStartup.addListener(() => {
  * 消息处理
  */
 chrome.runtime.onMessage.addListener(((msg, sender, sendResponse) => {
+  logger.debug('chrome.runtime.onMessage received:', msg)
   switch (msg?.type) {
     case 'storage.import': {
       if (!msg.storage) {
+        logger.warn('storage.import failed: message storage is empty')
         sendResponse<'storage.import'>({
           ok: false,
           message: 'message storage is empty'
@@ -52,6 +58,7 @@ chrome.runtime.onMessage.addListener(((msg, sender, sendResponse) => {
       }
 
       importContext(msg.storage).then((storage) => {
+        logger.debug('storage.import successful')
         sendResponse<'storage.import'>({
           ok: true,
           storage,
@@ -77,8 +84,10 @@ chrome.runtime.onMessage.addListener(((msg, sender, sendResponse) => {
       if (msg.api === 'userScripts') {
         try {
           chrome.userScripts.getScripts()
+          logger.debug('api.check: userScripts API available')
           sendResponse<'api.check'>(true)
         } catch (e) {
+          logger.error('api.check: userScripts API check failed:', e)
           sendResponse<'api.check'>(e as string)
         }
       }
@@ -100,6 +109,9 @@ chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
   if (changeInfo.status === 'loading') {
     const { storage, whitelistHelper, blacklistHelper } = await getLocalStorage()
 
+    logger.debug('chrome.tabs.onUpdated:', tab.title || tab.url || tab.id);
+    logger.debug('injectScript with storage:', storage)
+
     // 兼容模式注入，内部判断是否需要注入
     injectScript(tabId, storage)
 
@@ -108,10 +120,12 @@ chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
 
     if (storage.policies.isBlacklistMode) {
       if (blacklistHelper.match(_url.hostname)) {
+        logger.debug('in blacklist mode', _url.hostname);
         reRequestHeader(undefined, tabId)
       }
     } else {
       if (whitelistHelper.match(_url.hostname)) {
+        logger.debug('in whitelist mode', _url.hostname);
         reRequestHeader(tabId)
         setBadgeWhitelist(tabId)
       }
@@ -133,6 +147,7 @@ chrome.tabs.onRemoved.addListener((tabId) => {
  * 监听权限添加
  */
 chrome.permissions.onAdded.addListener((perms) => {
+  logger.info('chrome.permissions.onAdded triggered:', perms)
   if (perms.permissions?.includes('userScripts')) {
     reRegisterScript()
   }

--- a/src/background/request.ts
+++ b/src/background/request.ts
@@ -2,6 +2,9 @@ import { getBrowser } from "@/utils/equipment"
 import { getLocalStorage } from "./storage"
 import { HookType } from '@/types/enum'
 import { isDefaultMode } from "@/utils/storage"
+import { logManager } from '@/utils/log';
+
+const logger = logManager.createLogger(__LOG_PREFIX_FILE_PATH__);
 
 type RuleHeader = chrome.declarativeNetRequest.ModifyHeaderInfo
 
@@ -58,6 +61,8 @@ const genUaRules = async ({ config }: LocalStorage): Promise<readonly RuleHeader
     makeRule("Sec-Ch-Ua-Full-Version-List", fullVersionList.map((brand) => `"${brand.brand}";v="${brand.version}"`).join(", ")),
   ].filter(Boolean) as RuleHeader[]
 
+  logger.debug('genUaRules:', res)
+
   return res;
 }
 
@@ -82,6 +87,8 @@ const genLanguageRules = ({ config }: LocalStorage): readonly RuleHeader[] => {
       value: [first, ...rest].join(","),
     })
   }
+
+  logger.debug('genLanguageRules:', res)
 
   return res;
 }
@@ -159,6 +166,8 @@ export const reRequestHeader = async (excludeTabId?: number, includeTabId?: numb
     }
   }
 
+  logger.debug('reRequestHeader', 'rules:', rules, '\ncondition:', condition)
+
   /* 更新 SessionRules */
   await chrome.declarativeNetRequest.updateSessionRules({
     removeRuleIds: [UA_NET_RULE_ID],
@@ -170,5 +179,7 @@ export const reRequestHeader = async (excludeTabId?: number, includeTabId?: numb
         requestHeaders: rules,
       },
     }]
-  }).catch(() => { })
+  }).catch((e) => {
+    logger.error('reRequestHeader updateSessionRules error:', e);
+  })
 }

--- a/src/background/script.ts
+++ b/src/background/script.ts
@@ -1,5 +1,8 @@
 import { getLocalStorage, updateContext } from "./storage";
 import { coreInject } from "@/core/output";
+import { logManager } from '@/utils/log';
+
+const logger = logManager.createLogger(__LOG_PREFIX_FILE_PATH__);
 
 // // @ts-ignore
 // import contentSrc from '@/scripts/content?script&module'
@@ -38,6 +41,7 @@ export const ensureFastInject = (storage: LocalStorage) => {
  */
 export const injectScript = async (tabId: number, storage: LocalStorage) => {
   if (!storage.config.enable || ensureFastInject(storage)) return;
+  logger.debug('injectScript in compatibility mode:', tabId, storage);
   /* 注入脚本 */
   await chrome.scripting.executeScript({
     target: {
@@ -66,6 +70,7 @@ export const reRegisterScript = async () => {
   const { storage } = await getLocalStorage()
   if (!ensureFastInject(storage)) return;
 
+  logger.debug('injectScript in fast mode:', storage);
   if (storage.config.enable) {
     const scripts: chrome.userScripts.RegisteredUserScript[] = [{
       id: REG_ID,

--- a/src/background/script.ts
+++ b/src/background/script.ts
@@ -87,6 +87,6 @@ export const reRegisterScript = async () => {
       await chrome.userScripts.register(scripts)
     }
   } else {
-    chrome.userScripts.unregister({ ids: [REG_ID] })
+    chrome.userScripts.unregister({ ids: [REG_ID] }).catch(() => { });
   }
 }

--- a/src/background/script.ts
+++ b/src/background/script.ts
@@ -70,7 +70,7 @@ export const reRegisterScript = async () => {
   const { storage } = await getLocalStorage()
   if (!ensureFastInject(storage)) return;
 
-  logger.debug('injectScript in fast mode:', storage);
+  logger.debug('update injectScript in fast mode:', storage);
   if (storage.config.enable) {
     const scripts: chrome.userScripts.RegisteredUserScript[] = [{
       id: REG_ID,

--- a/src/background/storage.ts
+++ b/src/background/storage.ts
@@ -79,6 +79,7 @@ export const genDefaultLocalStorage = (): LocalStorage => {
       prefs: {
         language: navigator.language,
         theme: 'system',
+        logLevel: 'INFO',
       },
     },
     policies: {

--- a/src/background/storage.ts
+++ b/src/background/storage.ts
@@ -4,6 +4,7 @@ import { reRequestHeader } from "./request";
 import { HookType } from '@/types/enum'
 import { hasUserScripts, reRegisterScript } from "./script";
 import { SiteListHelper } from "./policies";
+import { logManager } from "@/utils/log";
 
 let mContent: LocalStorageContext | undefined
 
@@ -79,7 +80,7 @@ export const genDefaultLocalStorage = (): LocalStorage => {
       prefs: {
         language: navigator.language,
         theme: 'system',
-        logLevel: 'INFO',
+        logLevel: 'ERROR',
       },
     },
     policies: {
@@ -144,6 +145,7 @@ export const initLocalStorage = sharedAsync(async () => {
   if (rem.length) {
     chrome.storage.local.remove(rem)
   }
+
   /* set */
   const _storage: LocalStorage = {
     version: _new.version,
@@ -154,6 +156,14 @@ export const initLocalStorage = sharedAsync(async () => {
       isBlacklistMode: _curr.policies?.isBlacklistMode ?? _new.policies.isBlacklistMode,
     },
   }
+
+  /** 刷新浏览器种子 */
+  _storage.config.seed.browser = genRandomSeed()
+
+  /** 更新日志等级 */
+  logManager.setLevel(_storage.config.prefs.logLevel)
+
+  /** 其他 */
   mContent = genStorageContent(_storage)
   chrome.storage.local.set(_storage).then(() => {
     reRegisterScript()

--- a/src/core/core.ts
+++ b/src/core/core.ts
@@ -3,6 +3,9 @@ import { seededRandom } from "@/utils/base";
 import { genRandomSeed } from "../utils/base";
 import { hookTasks } from "./tasks";
 import { notify, notifyIframeOrigin } from './utils';
+import { logManager } from '@/utils/log';
+
+const logger = logManager.createLogger(__LOG_PREFIX_FILE_PATH__);
 
 export type HookTask = {
   // 条件，为空则默认为true
@@ -312,6 +315,8 @@ export class FingerprintContext {
 
   private constructor(gthis: any, opt: ContextOptions) {
     if (!gthis) throw new Error('gthis is required');
+
+    logger.debug("init FingerprintContext with options", opt);
 
     const { info, conf } = opt;
 

--- a/src/core/core.ts
+++ b/src/core/core.ts
@@ -5,8 +5,6 @@ import { hookTasks } from "./tasks";
 import { notify, notifyIframeOrigin } from './utils';
 import { logManager } from '@/utils/log';
 
-const logger = logManager.createLogger(__LOG_PREFIX_FILE_PATH__);
-
 export type HookTask = {
   // 条件，为空则默认为true
   condition?: (ctx: FingerprintContext) => boolean | undefined
@@ -27,6 +25,8 @@ type SeedInfo = {
 type ContextOptions = Pick<FingerprintContext, 'info' | 'conf'> & Partial<FingerprintContext>
 
 export class FingerprintContext {
+  /** 不同上下文有不同的日志 */
+  private logger = logManager.createLogger("FingerprintContext");
   public gthis: Window & WorkerGlobalScope & typeof globalThis
   public win?: Window & typeof globalThis
   public worker?: WorkerGlobalScope & typeof globalThis
@@ -316,8 +316,6 @@ export class FingerprintContext {
   private constructor(gthis: any, opt: ContextOptions) {
     if (!gthis) throw new Error('gthis is required');
 
-    logger.debug("init FingerprintContext with options", opt);
-
     const { info, conf } = opt;
 
     this.gthis = gthis
@@ -346,7 +344,12 @@ export class FingerprintContext {
       this.worker = gthis
     }
 
+    this.logger.setScope(gthis);
+    this.logger.debug("init with options", opt);
+
     this.runHook()
+
+    this.logger.info("init done");
   }
 
   public static hookWindow = (win: Window, opt: ContextOptions) => {

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -2,6 +2,9 @@ import { FingerprintContext, WIN_KEY } from "./core";
 import { genRandomSeed, existParentDomain } from "@/utils/base";
 import { getBrowser } from "@/utils/equipment";
 import { sendToWindow } from "@/utils/message";
+import { logManager } from '@/utils/log';
+
+const logger = logManager.createLogger(__LOG_PREFIX_FILE_PATH__);
 
 // @ts-ignore
 const args = _args;
@@ -10,6 +13,8 @@ const args = _args;
 // script entry
 // ------------
 (() => {
+  logger.debug("coreInject args", args);
+
   if (typeof window !== "undefined") {
     // @ts-ignore
     if (!args.fun && typeof coreInject === 'function') args.fun = coreInject;

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -13,6 +13,17 @@ const args = _args;
 // script entry
 // ------------
 (() => {
+  const logLevel = args?.storage?.config?.prefs?.logLevel as LogLevelString | undefined;
+
+  if (logLevel) {
+    if (logLevel !== "INFO") {
+      logger.info("set logLevel", logLevel);
+      logManager.setLevel(logLevel);
+    }
+  } else {
+    logger.warn("get logLevel from storage failed");
+  }
+
   logger.debug("coreInject args", args);
 
   if (typeof window !== "undefined") {

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -13,24 +13,21 @@ const args = _args;
 // script entry
 // ------------
 (() => {
-  const logLevel = args?.storage?.config?.prefs?.logLevel as LogLevelString | undefined;
+  const storage: LocalStorage | undefined = args.storage;
 
-  if (logLevel) {
-    if (logLevel !== "INFO") {
-      logger.info("set logLevel", logLevel);
-      logManager.setLevel(logLevel);
-    }
-  } else {
+  let logLevel = storage?.config?.prefs?.logLevel as LogLevelString | undefined;
+
+  if (!logLevel) {
     logger.warn("get logLevel from storage failed");
+    logLevel = "INFO";
   }
+  logManager.setLevel(logLevel);
 
   logger.debug("coreInject args", args);
 
   if (typeof window !== "undefined") {
     // @ts-ignore
     if (!args.fun && typeof coreInject === 'function') args.fun = coreInject;
-
-    const storage: LocalStorage = args.storage;
     if (!window || !storage) return;
 
     const hook = (win: Window & typeof globalThis, data: WindowStorage | undefined) => {

--- a/src/locales/en_US.json
+++ b/src/locales/en_US.json
@@ -91,6 +91,7 @@
       "serviceWorker": "Service Worker Interface",
       "e-language": "Language",
       "theme": "Theme",
+      "log-level": "Log Level",
       "seed": "Global Seed",
       "fast-inject": "Fast Inject Mode"
     },
@@ -125,6 +126,7 @@
       ],
       "e-language": "Language",
       "theme": "Theme",
+      "log-level": "Only show logs at or above the selected level",
       "seed": "Global Seed, Acts on **Random by Global Seed** Options",
       "fast-inject": [
         "When enabled, a faster script injection method will be used, requiring browser support; when disabled, compatibility mode is applied.",

--- a/src/locales/zh_CN.json
+++ b/src/locales/zh_CN.json
@@ -94,6 +94,7 @@
       "serviceWorker": "Service Worker 接口",
       "e-language": "语言",
       "theme": "主题",
+      "log-level": "日志",
       "seed": "全局种子",
       "fast-inject": "快速注入模式"
     },
@@ -128,6 +129,7 @@
       ],
       "e-language": "语言",
       "theme": "主题",
+      "log-level": "只输出不小于当前等级的日志",
       "seed": "全局种子，作用于 **根据全局种子随机值** 选项",
       "fast-inject": [
         "开启后，会使用更快速的脚本注入方式，需要浏览器支持；关闭则为兼容模式",

--- a/src/locales/zh_CN.json
+++ b/src/locales/zh_CN.json
@@ -94,7 +94,7 @@
       "serviceWorker": "Service Worker 接口",
       "e-language": "语言",
       "theme": "主题",
-      "log-level": "日志",
+      "log-level": "日志等级",
       "seed": "全局种子",
       "fast-inject": "快速注入模式"
     },

--- a/src/popup/App.tsx
+++ b/src/popup/App.tsx
@@ -29,15 +29,19 @@ function Application() {
 
   const { version, config, policies, loadStorage, saveConfig, savePolicies } = useStorageStore()
 
-  const logLevel = config?.prefs.logLevel;
-  logLevel && logManager.setLevel(logLevel);
-
   const isShowConfigBadge = !config?.action.fastInject;
   const policyMode = policies?.isBlacklistMode ? 'blacklist' : 'whitelist';
 
   useEffect(() => {
     loadStorage();
   }, [])
+
+  useEffect(() => {
+    const level = config?.prefs?.logLevel;
+    if (level) {
+      logManager.setLevel(level);
+    }
+  }, [config?.prefs?.logLevel])
 
   useEffect(() => {
     chrome.tabs.query({ active: true, currentWindow: true }).then(tabs => {

--- a/src/popup/App.tsx
+++ b/src/popup/App.tsx
@@ -14,6 +14,8 @@ import { sendToBackground } from "@/utils/message";
 import { NoticePanel } from "./record";
 import PoliciesView from "./policies";
 
+import { logManager } from '@/utils/log';
+
 function Application() {
   const [t, i18n] = useTranslation()
   const [tab, setTab] = useState<chrome.tabs.Tab>()
@@ -26,6 +28,9 @@ function Application() {
   const manifest = useMemo<chrome.runtime.Manifest>(() => chrome.runtime.getManifest(), [])
 
   const { version, config, policies, loadStorage, saveConfig, savePolicies } = useStorageStore()
+
+  const logLevel = config?.prefs.logLevel;
+  logLevel && logManager.setLevel(logLevel);
 
   const isShowConfigBadge = !config?.action.fastInject;
   const policyMode = policies?.isBlacklistMode ? 'blacklist' : 'whitelist';

--- a/src/popup/config/group/prefs.tsx
+++ b/src/popup/config/group/prefs.tsx
@@ -7,6 +7,7 @@ import { LoadingOutlined } from '@ant-design/icons'
 import { usePrefsStore } from "@/popup/stores/prefs";
 import { ConfigDesc, ConfigItemY } from "../item";
 import { useShallow } from "zustand/shallow";
+import { logManager } from "@/utils/log";
 
 const LANG_OPTIONS = [
   {
@@ -91,11 +92,11 @@ export const PrefsConfigGroup = memo(() => {
     >
       <Select
         options={LOG_LEVEL_OPTIONS}
-        value={prefs.logLevel || 'info'}
+        value={config.prefs.logLevel}
         onChange={(value) => {
           config.prefs.logLevel = value
           saveConfig()
-          prefs.setLogLevel(value)
+          logManager.setLevel(value);
         }}
       />
     </ConfigItemY>

--- a/src/popup/config/group/prefs.tsx
+++ b/src/popup/config/group/prefs.tsx
@@ -19,6 +19,14 @@ const LANG_OPTIONS = [
   }
 ]
 
+const LOG_LEVEL_OPTIONS = [
+  { label: '1 - DEBUG', value: 'DEBUG' },
+  { label: '2 - INFO', value: 'INFO' },
+  { label: '3 - WARN', value: 'WARN' },
+  { label: '4 - ERROR', value: 'ERROR' },
+  { label: '5 - NONE', value: 'NONE' }
+]
+
 const nsImportTag = ['unsupport-import']
 
 export const PrefsConfigGroup = memo(() => {
@@ -73,6 +81,21 @@ export const PrefsConfigGroup = memo(() => {
           config.prefs.theme = value
           saveConfig()
           prefs.setTheme(value)
+        }}
+      />
+    </ConfigItemY>
+
+    <ConfigItemY
+      label={t('item.title.log-level')}
+      endContent={<TipIcon.Question content={<ConfigDesc tags={nsImportTag} desc={t('item.desc.log-level')} />} />}
+    >
+      <Select
+        options={LOG_LEVEL_OPTIONS}
+        value={prefs.logLevel || 'info'}
+        onChange={(value) => {
+          config.prefs.logLevel = value
+          saveConfig()
+          prefs.setLogLevel(value)
         }}
       />
     </ConfigItemY>

--- a/src/popup/stores/prefs.ts
+++ b/src/popup/stores/prefs.ts
@@ -2,14 +2,12 @@ import i18n from "@/locales"
 import { theme, type ThemeConfig } from "antd"
 import { create } from "zustand"
 import { persist, createJSONStorage } from 'zustand/middleware'
-import { logManager } from '@/utils/log';
 
 type Theme = LocalStorageConfig['prefs']['theme']
 
 type State = {
   theme: Theme
   language: string,
-  logLevel: LogLevelString,
 }
 
 type Actions = {
@@ -18,9 +16,6 @@ type Actions = {
 
   initLanguage: () => void
   setLanguage: (language: string) => void
-
-  setLogLevel: (logLevel: LogLevelString) => void 
-  getLogLevel: () => LogLevelString
 }
 
 /**
@@ -77,7 +72,6 @@ export const usePrefsStore = create<State & Actions>()(
     return {
       theme: 'system',
       language: getLanguage(navigator.language),
-      logLevel: 'INFO',
 
       getThemeName: (theme?: string) => {
         const t = theme ?? get().theme;
@@ -112,14 +106,6 @@ export const usePrefsStore = create<State & Actions>()(
         i18n.changeLanguage(lang)
         set({ language: lang })
       },
-
-      setLogLevel: (logLevel: LogLevelString) => {
-        logManager.setLevel(logLevel)
-        set({ logLevel })
-      },
-      getLogLevel: () => {
-        return get().logLevel
-      }
     }
   }, {
     version: 1,
@@ -128,7 +114,6 @@ export const usePrefsStore = create<State & Actions>()(
     partialize: (s) => ({
       theme: s.theme,
       language: s.language,
-      logLevel: s.logLevel
     }) as any,
     onRehydrateStorage: () => (state) => {
       if (!state) return;

--- a/src/popup/stores/prefs.ts
+++ b/src/popup/stores/prefs.ts
@@ -2,12 +2,14 @@ import i18n from "@/locales"
 import { theme, type ThemeConfig } from "antd"
 import { create } from "zustand"
 import { persist, createJSONStorage } from 'zustand/middleware'
+import { logManager } from '@/utils/log';
 
 type Theme = LocalStorageConfig['prefs']['theme']
 
 type State = {
   theme: Theme
-  language: string
+  language: string,
+  logLevel: LogLevelString,
 }
 
 type Actions = {
@@ -16,6 +18,9 @@ type Actions = {
 
   initLanguage: () => void
   setLanguage: (language: string) => void
+
+  setLogLevel: (logLevel: LogLevelString) => void 
+  getLogLevel: () => LogLevelString
 }
 
 /**
@@ -72,6 +77,7 @@ export const usePrefsStore = create<State & Actions>()(
     return {
       theme: 'system',
       language: getLanguage(navigator.language),
+      logLevel: 'INFO',
 
       getThemeName: (theme?: string) => {
         const t = theme ?? get().theme;
@@ -105,6 +111,14 @@ export const usePrefsStore = create<State & Actions>()(
         const lang = getLanguage(language)
         i18n.changeLanguage(lang)
         set({ language: lang })
+      },
+
+      setLogLevel: (logLevel: LogLevelString) => {
+        logManager.setLevel(logLevel)
+        set({ logLevel })
+      },
+      getLogLevel: () => {
+        return get().logLevel
       }
     }
   }, {
@@ -113,7 +127,8 @@ export const usePrefsStore = create<State & Actions>()(
     storage: createJSONStorage(() => localStorage),
     partialize: (s) => ({
       theme: s.theme,
-      language: s.language
+      language: s.language,
+      logLevel: s.logLevel
     }) as any,
     onRehydrateStorage: () => (state) => {
       if (!state) return;

--- a/src/types/data.d.ts
+++ b/src/types/data.d.ts
@@ -80,3 +80,9 @@ type ClientHintsInfo = {
 }
 
 type I18nString = string | Record<string, string>
+
+/** 使用文件路径作为日志前缀时，需要在编译期间进行处理。
+ * 
+ * 这是一个占位符，后期需要配合插件，将其替换成真实的文件路径
+ */
+declare const __LOG_PREFIX_FILE_PATH__: string;

--- a/src/types/storage.d.ts
+++ b/src/types/storage.d.ts
@@ -4,6 +4,8 @@ type LocalStorage = {
   policies: LocalStoragePolicies  // 策略
 }
 
+type LogLevelString = "DEBUG" | "INFO" | "WARN" | "ERROR" | "NONE";
+
 type LocalStorageConfig = {
   enable: boolean
   // 种子
@@ -28,7 +30,8 @@ type LocalStorageConfig = {
   // 其他
   prefs: {
     language: string
-    theme: 'system' | 'light' | 'dark'
+    theme: 'system' | 'light' | 'dark',
+    logLevel: LogLevelString
   }
 }
 

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -54,16 +54,15 @@ const ScopeMap: Record<string, ScriptScope> = {
  *
  * 因为脚本会注入到网站的不同上下文中，如 worker 等等，需要标识它们，以便区分日志来源。
  */
-function getScriptScope(): ScriptScope {
-  // 此处不能使用 window 哟
-  const name = Reflect.get(globalThis, Symbol.toStringTag);
+function getScriptScope(global: any = globalThis): ScriptScope {
+  const name = Reflect.get(global, Symbol.toStringTag);
   if (!name) {
     return "Window";
   }
 
   let scope = ScopeMap[name];
   // @ts-ignore
-  if (scope === "Window" && globalThis !== globalThis.top) {
+  if (scope === "Window" && global !== global.top) {
     scope = "IFrame";
   }
 
@@ -91,7 +90,7 @@ class Logger {
   /** 输出脚本所在作用域的样式，竹青色 */
   private static readonly scopeStyle = "color: #789262";
   /** 当前脚本所在的作用域 */
-  private static readonly scope = getScriptScope();
+  private scope = getScriptScope();
   /** 不同日志等级使用对应的日志输出方法 */
   private static readonly LogMethodMap: Record<
     LogLevel,
@@ -117,6 +116,10 @@ class Logger {
     return this.level;
   }
 
+  setScope(global: any) {
+    this.scope = getScriptScope(global);
+  }
+
   /** 输出特定等级的日志 */
   private logLevel(level: LogLevel, args: unknown[]) {
     // 当【日志级别 >= 当前设置级别的日志】才输出
@@ -127,7 +130,7 @@ class Logger {
     const log = Logger.LogMethodMap[level];
 
     log(
-      `%c${timestamp} %c[${Logger.extensionName}] %c@${Logger.scope} - %c${levelName} %c[${this.prefix}]`,
+      `%c${timestamp} %c[${Logger.extensionName}] %c@${this.scope} - %c${levelName} %c[${this.prefix}]`,
       Logger.timestampStyle,
       Logger.prefixStyle,
       Logger.scopeStyle,
@@ -170,7 +173,6 @@ class LogManager {
     const logger = new Logger(level, prefix);
     // TODO: 后续应该将这么修改为 LogLevel.INFO
     logger.setLevel(LogLevel.DEBUG);
-    logger.warn("dev mode, init logger with DEBUG Level, remove me!");
     this.loggers.push(logger);
     return logger;
   }

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -1,0 +1,201 @@
+/** 日志输出 */
+
+// #region log level and style
+
+// 保留副本，避免被网站清空
+const log = console.log;
+const warn = console.warn;
+const error = console.error;
+
+/** 日志等级。数字越大，等级越高，输出的日志越少。
+ *
+ * 注意日志等级顺序固定，方便后续过滤日志。
+ *
+ * 比如设置日志等级为 INFO，则 DEBUG 级别的日志不会输出，INFO 及以上级别的日志会输出。
+ *
+ */
+export enum LogLevel {
+  DEBUG,
+  INFO,
+  WARN,
+  ERROR,
+  /** 不输出任何日志 */
+  NONE,
+}
+
+/** 输出日志时的 css style */
+const LogStyle: Record<LogLevel, string> = {
+  [LogLevel.DEBUG]: "color: #bc64a4", // 若紫
+  [LogLevel.INFO]: "color: #ff8936", // 橘黄
+  [LogLevel.WARN]: "color: #f2be45", // 赤金
+  [LogLevel.ERROR]: "color: #cb3a56", // 茜色
+  [LogLevel.NONE]: "", // 不输出日志时不需要样式
+};
+
+// #endregion
+
+// #region script scope
+
+type ScriptScope =
+  | "Window"
+  | "IFrame"
+  | "Worker"
+  | "SharedWorker"
+  | "ServiceWorker";
+
+const ScopeMap: Record<string, ScriptScope> = {
+  Window: "Window",
+  DedicatedWorkerGlobalScope: "Worker",
+  SharedWorkerGlobalScope: "SharedWorker",
+  ServiceWorkerGlobalScope: "ServiceWorker",
+};
+
+/** 获取当前脚本所在的作用域。
+ *
+ * 因为脚本会注入到网站的不同上下文中，如 worker 等等，需要标识它们，以便区分日志来源。
+ */
+function getScriptScope(): ScriptScope {
+  // 此处不能使用 window 哟
+  const name = Reflect.get(globalThis, Symbol.toStringTag);
+  if (!name) {
+    return "Window";
+  }
+
+  let scope = ScopeMap[name];
+  // @ts-ignore
+  if (scope === "Window" && globalThis !== globalThis.top) {
+    scope = "IFrame";
+  }
+
+  return scope;
+}
+
+// #endregion
+
+/** 日志输出。
+ *
+ * 可以每一个文件都有独自的 Logger 实例，设置其前缀为文件的路径，
+ *
+ * 以便区分日志来源，方便后续排查问题。
+ */
+class Logger {
+  /** 当前日志等级 */
+  private level: LogLevel;
+  /** 日志前缀，用于区分不同功能 */
+  private readonly prefix: string;
+  private static readonly extensionName = "my-fingerprint";
+  /** 输出插件名称、prefix 的样式，青碧色 */
+  private static readonly prefixStyle = "color: #48c0a3";
+  /** 输出时间戳时的样式 */
+  private static readonly timestampStyle = "color: #aaa";
+  /** 输出脚本所在作用域的样式，竹青色 */
+  private static readonly scopeStyle = "color: #789262";
+  /** 当前脚本所在的作用域 */
+  private static readonly scope = getScriptScope();
+  /** 不同日志等级使用对应的日志输出方法 */
+  private static readonly LogMethodMap: Record<
+    LogLevel,
+    (...args: unknown[]) => void
+  > = {
+    [LogLevel.DEBUG]: log,
+    [LogLevel.INFO]: log,
+    [LogLevel.WARN]: warn,
+    [LogLevel.ERROR]: error,
+    [LogLevel.NONE]: () => {},
+  };
+
+  constructor(level: LogLevel, prefix: string) {
+    this.level = level;
+    this.prefix = prefix;
+  }
+
+  setLevel(level: LogLevel) {
+    this.level = level;
+  }
+
+  getLevel(): LogLevel {
+    return this.level;
+  }
+
+  /** 输出特定等级的日志 */
+  private logLevel(level: LogLevel, args: unknown[]) {
+    // 当【日志级别 >= 当前设置级别的日志】才输出
+    if (level < this.level || this.level === LogLevel.NONE) return;
+
+    const timestamp = new Date().toISOString();
+    const levelName = LogLevel[level];
+    const log = Logger.LogMethodMap[level];
+
+    log(
+      `%c${timestamp} %c[${Logger.extensionName}] %c@${Logger.scope} - %c${levelName} %c[${this.prefix}]`,
+      Logger.timestampStyle,
+      Logger.prefixStyle,
+      Logger.scopeStyle,
+      LogStyle[level],
+      Logger.prefixStyle,
+      ...args,
+    );
+  }
+
+  /** 输出 debug 级别日志 */
+  debug(...args: any[]) {
+    this.logLevel(LogLevel.DEBUG, args);
+  }
+
+  /** 输出 info 级别日志 */
+  info(...args: any[]) {
+    this.logLevel(LogLevel.INFO, args);
+  }
+
+  /** 输出 warn 级别日志 */
+  warn(...args: any[]) {
+    this.logLevel(LogLevel.WARN, args);
+  }
+
+  /** 输出 error 级别日志 */
+  error(...args: any[]) {
+    this.logLevel(LogLevel.ERROR, args);
+  }
+}
+
+/** 管理所有创建的日志，方便统一调整它们的日志等级 */
+class LogManager {
+  private loggers: Logger[] = [];
+
+  /** 创建一个新的 Logger 实例，默认输出 INFO 日志，并添加到管理器中。
+   *
+   * @param prefix 通常是文件路径，或者模块、功能的名称
+   */
+  createLogger(prefix: string, level = LogLevel.INFO): Logger {
+    const logger = new Logger(level, prefix);
+    // TODO: 后续应该将这么修改为 LogLevel.INFO
+    logger.setLevel(LogLevel.DEBUG);
+    logger.warn("dev mode, init logger with DEBUG Level, remove me!");
+    this.loggers.push(logger);
+    return logger;
+  }
+
+  /** 清空所有日志实例 */
+  clear() {
+    // 避免其它地方调用时依然有输出
+    this.setLevel(LogLevel.NONE);
+    this.loggers = [];
+  }
+
+  /** 设置所有 Logger 实例的日志等级 */
+  setLevel(level: LogLevel) {
+    this.loggers.forEach((logger) => logger.setLevel(level));
+  }
+}
+
+/** 日志管理器，同一个作用域下只有一个该实例。
+ *
+ * 在插件的 `background`、`content`、`popup` 等不同上下文中，
+ *  都会使用这个日志管理器创建 Logger 实例。
+ *
+ * ```ts
+ * // 标识日志前缀，方便区分日志来源
+ * const logger = logManager.createLogger("core", LogLevel.DEBUG);
+ * ```
+ */
+export const logManager = new LogManager();

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -188,6 +188,7 @@ class LogManager {
   /** 设置所有 Logger 实例的日志等级 */
   setLevel(level: LogLevel | LogLevelString) {
     const v = typeof level === "string" ? LogLevel[level] : level;
+    if (v === this.current_level) return;
     this.current_level = v;
     this.loggers.forEach((logger) => logger.setLevel(v));
   }

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -96,12 +96,12 @@ class Logger {
     LogLevel,
     (...args: unknown[]) => void
   > = {
-    [LogLevel.DEBUG]: log,
-    [LogLevel.INFO]: log,
-    [LogLevel.WARN]: warn,
-    [LogLevel.ERROR]: error,
-    [LogLevel.NONE]: () => {},
-  };
+      [LogLevel.DEBUG]: log,
+      [LogLevel.INFO]: log,
+      [LogLevel.WARN]: warn,
+      [LogLevel.ERROR]: error,
+      [LogLevel.NONE]: () => { },
+    };
 
   constructor(level: LogLevel, prefix: string) {
     this.level = level;
@@ -185,8 +185,9 @@ class LogManager {
   }
 
   /** 设置所有 Logger 实例的日志等级 */
-  setLevel(level: LogLevel) {
-    this.loggers.forEach((logger) => logger.setLevel(level));
+  setLevel(level: LogLevel | LogLevelString) {
+    const v = typeof level === "string" ? LogLevel[level] : level;
+    this.loggers.forEach((logger) => logger.setLevel(v));
   }
 }
 

--- a/src/utils/log.ts
+++ b/src/utils/log.ts
@@ -164,15 +164,16 @@ class Logger {
 /** 管理所有创建的日志，方便统一调整它们的日志等级 */
 class LogManager {
   private loggers: Logger[] = [];
+  /** 当前插件设置的日志等级 */
+  private current_level: LogLevel = LogLevel.INFO;
 
   /** 创建一个新的 Logger 实例，默认输出 INFO 日志，并添加到管理器中。
    *
    * @param prefix 通常是文件路径，或者模块、功能的名称
    */
   createLogger(prefix: string, level = LogLevel.INFO): Logger {
+    level = Math.max(level, this.current_level);
     const logger = new Logger(level, prefix);
-    // TODO: 后续应该将这么修改为 LogLevel.INFO
-    logger.setLevel(LogLevel.DEBUG);
     this.loggers.push(logger);
     return logger;
   }
@@ -187,7 +188,16 @@ class LogManager {
   /** 设置所有 Logger 实例的日志等级 */
   setLevel(level: LogLevel | LogLevelString) {
     const v = typeof level === "string" ? LogLevel[level] : level;
+    this.current_level = v;
     this.loggers.forEach((logger) => logger.setLevel(v));
+  }
+
+  getLevel(): LogLevel {
+    return this.current_level;
+  }
+
+  getLevelString(): LogLevelString {
+    return LogLevel[this.current_level] as LogLevelString;
   }
 }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,8 @@ import { resolve } from 'path'
 import { crx } from "@crxjs/vite-plugin"
 import { firefoxManifest, chromeManifest } from './manifest'
 import { coreBundle } from "./plugins/core-bundle";
+import genLogPrefix from "./plugins/gen-log-prefix";
+
 // import { type ManifestV3Export } from "@crxjs/vite-plugin"
 
 const args = process.argv
@@ -19,6 +21,7 @@ export default defineConfig({
       functionName: 'coreInject',
       params: '_args',
     }),
+    genLogPrefix("__LOG_PREFIX_FILE_PATH__") as any,
     react(),
     crx({
       browser: isFirefox ? 'firefox' : 'chrome',


### PR DESCRIPTION
简要说明：实现基本的 `log API`，以及一个 `vite plugin gen-log-prefix`，它将文件的相对路径作为日志的前缀。

相关讨论：#106 