### PR TITLE
Fix fast inject userScripts checks and empty DNR conditions

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -1,6 +1,6 @@
 import { getLocalStorage, importContext, initLocalStorage, updateContext } from "./storage";
 import { removeBadge, setBadgeContent, setBadgeWhitelist } from "./badge";
-import { injectScript, reRegisterScript } from './script';
+import { hasUserScripts, injectScript, reRegisterScript } from './script';
 import { existParentDomain, tryUrl } from "@/utils/base";
 import { reRequestHeader } from "./request";
 import { logManager } from '@/utils/log';
@@ -91,14 +91,11 @@ chrome.runtime.onMessage.addListener(((msg, sender, sendResponse) => {
     }
     case 'api.check': {
       if (msg.api === 'userScripts') {
-        try {
-          chrome.userScripts.getScripts()
+        const available = hasUserScripts()
+        if (available) {
           logger.debug('api.check: userScripts API available')
-          sendResponse<'api.check'>(true)
-        } catch (e) {
-          logger.error('api.check: userScripts API check failed:', e)
-          sendResponse<'api.check'>(e as string)
         }
+        sendResponse<'api.check'>(available)
       }
       return false
     }

--- a/src/background/request.ts
+++ b/src/background/request.ts
@@ -134,6 +134,7 @@ export const reRequestHeader = async (excludeTabId?: number, includeTabId?: numb
 
   /* 构建 Condition */
   let condition: chrome.declarativeNetRequest.RuleCondition;
+  const resourceTypes = Object.values(chrome.declarativeNetRequest.ResourceType)
   if (storage.policies.isBlacklistMode) {
     /* 黑名单模式 */
     if (!MEMORY.includeTabIds) {
@@ -144,25 +145,32 @@ export const reRequestHeader = async (excludeTabId?: number, includeTabId?: numb
       MEMORY.includeTabIds = [...new Set(MEMORY.includeTabIds)]
     }
 
-    condition = {
-      resourceTypes: Object.values(chrome.declarativeNetRequest.ResourceType),
-      initiatorDomains: [...storage.policies.blacklist],
-      tabIds: [...MEMORY.includeTabIds],
+    condition = { resourceTypes }
+    if (storage.policies.blacklist.length > 0) {
+      condition.initiatorDomains = [...storage.policies.blacklist]
+    }
+    if (MEMORY.includeTabIds.length > 0) {
+      condition.tabIds = [...MEMORY.includeTabIds]
+    }
+    if (!condition.initiatorDomains && !condition.tabIds) {
+      return await removeRules()
     }
   } else {
     /* 白名单模式 */
     if (!MEMORY.excludeTabIds) {
-      MEMORY.excludeTabIds = srs[0]?.condition?.tabIds ?? []
+      MEMORY.excludeTabIds = srs[0]?.condition?.excludedTabIds ?? []
     }
     if (excludeTabId != null) {
       MEMORY.excludeTabIds.push(excludeTabId)
       MEMORY.excludeTabIds = [...new Set(MEMORY.excludeTabIds)]
     }
 
-    condition = {
-      resourceTypes: Object.values(chrome.declarativeNetRequest.ResourceType),
-      excludedInitiatorDomains: [...storage.policies.whitelist],
-      excludedTabIds: [...MEMORY.excludeTabIds],
+    condition = { resourceTypes }
+    if (storage.policies.whitelist.length > 0) {
+      condition.excludedInitiatorDomains = [...storage.policies.whitelist]
+    }
+    if (MEMORY.excludeTabIds.length > 0) {
+      condition.excludedTabIds = [...MEMORY.excludeTabIds]
     }
   }
 


### PR DESCRIPTION
## Summary

- reuse the existing `hasUserScripts()` guard for the fast-inject API availability check instead of directly calling `chrome.userScripts.getScripts()` from the message handler
- return a boolean availability result without logging expected unavailable states as extension errors
- omit empty `declarativeNetRequest` condition arrays and remove the header rule in blacklist mode when there is no matching domain or tab scope
- restore cached whitelist tab state from `excludedTabIds` rather than `tabIds`

## Why

Chrome can expose `chrome.userScripts` as unavailable in the extension service worker context when the API/toggle is not available. Enabling fast inject currently records an extension error:

```text
api.check: userScripts API check failed: TypeError: Cannot read properties of undefined (reading 'getScripts')
```

The request-header refresh path can also attempt to register a DNR rule with empty condition arrays, which Chrome rejects:

```text
Rule with id 1 cannot have an empty list as the value for initiatorDomains key.
Rule with id 1 cannot have an empty list as the value for tabIds key.
```

## Verification

- `npm run build`
- manually verified a local unpacked build by toggling fast inject off/on without producing a new `getScripts` extension error
